### PR TITLE
Update crud_python

### DIFF
--- a/crud_python
+++ b/crud_python
@@ -16,3 +16,15 @@ def lambda_handler(event, context):
     }
 
     try:
+
+     except KeyError: (JAYA)
+        statusCode = 400
+        body = 'Unsupported route: ' + event['routeKey']
+    
+    body = json.dumps(body)
+    res = {
+        "statusCode": statusCode,
+        "headers": headers,
+        "body": body
+    }
+    return res


### PR DESCRIPTION
crud_app

1. Blok try-except:
except KeyError: digunakan untuk menangani error KeyError.
KeyError terjadi jika kode mencoba mengakses kunci (key) tertentu di sebuah dictionary, tetapi kunci tersebut tidak ditemukan.
Dalam kasus ini, jika event['routeKey'] tidak ditemukan, maka kode akan masuk ke blok except.
2. Status Code 400 (Bad Request):
Jika terjadi KeyError, sistem akan memberikan status HTTP 400, yang menunjukkan bahwa permintaan klien (request) tidak valid atau tidak didukung.
3. Pesan Error di body:
body = 'Unsupported route: ' + event['routeKey'] mencoba memberi tahu bahwa route (rute API) yang diminta tidak ditemukan atau tidak didukung.
4. Mengubah Pesan Menjadi JSON:
json.dumps() digunakan untuk mengubah objek Python menjadi string JSON agar bisa dikirim sebagai bagian dari respons HTTP.
5. Membuat Respon (res):
res adalah dictionary yang berisi informasi untuk dikembalikan sebagai respons HTTP:
statusCode: Status kode HTTP (400 jika terjadi KeyError).
headers: Berisi metadata HTTP (misalnya Content-Type: application/json).
body: Isi respons, dalam bentuk JSON.
6. Mengembalikan respons
return res mengembalikan dictionary berisi status kode, header, dan body sebagai respons API.